### PR TITLE
property added for deploying different frameworks

### DIFF
--- a/lib/filestore.js
+++ b/lib/filestore.js
@@ -28,12 +28,12 @@ var SLASH_ESCAPED = '%2f';
  * @param {object} oOptions Options for FileStore
  * @returns {FileStore}
  */
-var FileStore = function (oOptions) {
+var FileStore = function(oOptions) {
     /*
      oOptions
      - conn:[server, client, useStrictSSL]
      - auth:[user, pwd]
-     - ui5:[language, transportno, package, bspcontainer (max 15 chars), bspcontainer_text, calc_appindex]
+     - ui5:[language, transportno, package, bspcontainer (max 15 chars), bspcontainer_text, calc_appindex, is_ui5_framework]
      */
 
     // options
@@ -47,6 +47,11 @@ var FileStore = function (oOptions) {
     if (this._oOptions.conn && this._oOptions.conn.server) {
         this._oOptions.conn.server = this._oOptions.conn.server.replace(/\/*$/, '');
     }
+
+    if (!(typeof this._oOptions.is_ui5_framework === "boolean")) {
+        this._oOptions.is_ui5_framework = true;
+    }
+
 };
 
 /**
@@ -54,7 +59,7 @@ var FileStore = function (oOptions) {
  * @private
  * @returns {string}
  */
-FileStore.prototype._constructBaseUrl = function () {
+FileStore.prototype._constructBaseUrl = function() {
     return this._oOptions.conn.server + FILESTORE_BASE_URL;
 };
 
@@ -64,7 +69,7 @@ FileStore.prototype._constructBaseUrl = function () {
  * @param {object} oRequest Unirest request object
  * @param {function} fnRequestCallback Callback for unirest request
  */
-FileStore.prototype._sendRequest = function (oRequest, fnRequestCallback) {
+FileStore.prototype._sendRequest = function(oRequest, fnRequestCallback) {
     var me = this;
 
     if (me._oOptions.auth) {
@@ -77,7 +82,7 @@ FileStore.prototype._sendRequest = function (oRequest, fnRequestCallback) {
         });
     }
 
-    if (me._oOptions.ui5.language){
+    if (me._oOptions.ui5.language) {
         oRequest.query({
             'sap-language': encodeURIComponent(me._oOptions.ui5.language.toUpperCase())
         });
@@ -93,7 +98,7 @@ FileStore.prototype._sendRequest = function (oRequest, fnRequestCallback) {
  * @private
  * @param {function} fnCallback callback function
  */
-FileStore.prototype._determineCSRFToken = function (fnCallback) {
+FileStore.prototype._determineCSRFToken = function(fnCallback) {
     var me = this;
 
     if (me._sCSRFToken !== null) {
@@ -105,7 +110,7 @@ FileStore.prototype._determineCSRFToken = function (fnCallback) {
             'connection': 'keep-alive',
             'accept': '*/*'
         });
-        me._sendRequest(oRequest, function (oResponse) {
+        me._sendRequest(oRequest, function(oResponse) {
             if (oResponse.statusCode === util.HTTPSTAT.ok) {
                 me._sCSRFToken = oResponse.headers['x-csrf-token'];
                 me._sSAPCookie = oResponse.headers['set-cookie'];
@@ -120,10 +125,10 @@ FileStore.prototype._determineCSRFToken = function (fnCallback) {
  * @public
  * @param {function} fnCallback callback function
  */
-FileStore.prototype.getMetadataBSPContainer = function (fnCallback) {
+FileStore.prototype.getMetadataBSPContainer = function(fnCallback) {
     var sUrl = this._constructBaseUrl() + '/' + encodeURIComponent(this._oOptions.ui5.bspcontainer);
     var oRequest = unirest.get(sUrl);
-    this._sendRequest(oRequest, function (oResponse) {
+    this._sendRequest(oRequest, function(oResponse) {
         fnCallback(util.createResponseError(oRequest, oResponse), oResponse);
     });
 };
@@ -133,13 +138,13 @@ FileStore.prototype.getMetadataBSPContainer = function (fnCallback) {
  * @public
  * @param {function} fnCallback callback function
  */
-FileStore.prototype.createBSPContainer = function (fnCallback) {
+FileStore.prototype.createBSPContainer = function(fnCallback) {
     var me = this;
 
     async.series([
         me._determineCSRFToken.bind(me),
         me.getMetadataBSPContainer.bind(me)
-    ], function (oError, aResult) {
+    ], function(oError, aResult) {
         if (aResult[1].statusCode === util.HTTPSTAT.not_found) {
             // create BSP Container
             var sUrl = me._constructBaseUrl() +
@@ -153,17 +158,15 @@ FileStore.prototype.createBSPContainer = function (fnCallback) {
             }
 
             var oRequest = unirest.post(sUrl);
-            oRequest.headers(
-                {
-                    'X-CSRF-Token': me._sCSRFToken,
-                    'Content-Type': 'application/octet-stream',
-                    'Accept-Language': 'en-EN',
-                    'accept': '*/*',
-                    'Cookie': me._sSAPCookie
-                }
-            );
+            oRequest.headers({
+                'X-CSRF-Token': me._sCSRFToken,
+                'Content-Type': 'application/octet-stream',
+                'Accept-Language': 'en-EN',
+                'accept': '*/*',
+                'Cookie': me._sSAPCookie
+            });
 
-            me._sendRequest(oRequest, function (oResponse) {
+            me._sendRequest(oRequest, function(oResponse) {
                 var msg = 'BSP-Container ' + me._oOptions.ui5.bspcontainer + ' created.';
                 if (oResponse.statusCode === util.HTTPSTAT.created || oResponse.statusCode === util.HTTPSTAT.not_allowed) {
                     gutil.log(gutil.colors.green('[OK]'), msg);
@@ -184,7 +187,7 @@ FileStore.prototype.createBSPContainer = function (fnCallback) {
  * @public
  * @param {function} fnCallback callback function
  */
-FileStore.prototype.calcAppIndex = function (fnCallback) {
+FileStore.prototype.calcAppIndex = function(fnCallback) {
 
     if (!this._oOptions.ui5.calc_appindex) {
         // Option to recalculate the application index is not enabled - simply fire the callback
@@ -196,17 +199,15 @@ FileStore.prototype.calcAppIndex = function (fnCallback) {
     var sUrl = this._oOptions.conn.server + '/sap/bc/adt/filestore/ui5-bsp/appindex/' + encodeURIComponent(this._oOptions.ui5.bspcontainer);
 
     var oRequest = unirest.post(sUrl);
-    oRequest.headers(
-        {
-            'X-CSRF-Token': this._sCSRFToken,
-            'Content-Type': 'application/octet-stream',
-            'Accept-Language': 'en-EN',
-            'accept': '*/*',
-            'Cookie': this._sSAPCookie
-        }
-    );
+    oRequest.headers({
+        'X-CSRF-Token': this._sCSRFToken,
+        'Content-Type': 'application/octet-stream',
+        'Accept-Language': 'en-EN',
+        'accept': '*/*',
+        'Cookie': this._sSAPCookie
+    });
 
-    this._sendRequest(oRequest, function (oResponse) {
+    this._sendRequest(oRequest, function(oResponse) {
         var msg = 'Calculating application index.';
         if (oResponse.statusCode === util.HTTPSTAT.ok) {
             gutil.log(gutil.colors.green('[OK]'), msg);
@@ -225,7 +226,7 @@ FileStore.prototype.calcAppIndex = function (fnCallback) {
  * @param {string} sCwd base folder
  * @param {function} fnCallback callback function
  */
-FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
+FileStore.prototype.syncFiles = function(aFiles, sCwd, fnCallback) {
     var aArtifactsLocal = util.structureResolve(aFiles, '/');
     var aArtifactsServer = [];
     var aArtifactsSync = [];
@@ -235,24 +236,24 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
 
     async.series([
         // L1, step 1: determine artifacts which have to be uploaded
-        function (fnCallbackAsyncL1) {
+        function(fnCallbackAsyncL1) {
 
             async.series([
                 // L2, step 1: get files from server
-                function (fnCallbackAsyncL2) {
+                function(fnCallbackAsyncL2) {
                     var aFolders = [];
                     aFolders.push(me._oOptions.ui5.bspcontainer);
 
                     async.whilst(
-                        function () {
+                        function() {
                             return aFolders.length > 0;
                         },
-                        function (fnCallbackAsyncL3) {
+                        function(fnCallbackAsyncL3) {
                             var sFolder = aFolders.shift();
 
                             var oRequest = unirest.get(me._constructBaseUrl() + '/' + encodeURIComponent(sFolder) + '/content');
 
-                            me._sendRequest(oRequest, function (oResponse) {
+                            me._sendRequest(oRequest, function(oResponse) {
                                 if (oResponse.statusCode === util.HTTPSTAT.not_found) { //BSP container does not exist
                                     fnCallbackAsyncL3(null, oResponse);
                                     return;
@@ -266,7 +267,7 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
                                 var oXML = new XMLDocument(oResponse.body);
                                 var oAtomEntry = oXML.childrenNamed('atom:entry');
 
-                                oAtomEntry.forEach(function (oChild) {
+                                oAtomEntry.forEach(function(oChild) {
                                     var sCurrId = oChild.valueWithPath('atom:id');
                                     var sCurrType = oChild.valueWithPath('atom:category@term');
 
@@ -280,8 +281,8 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
                                 fnCallbackAsyncL3(null, oResponse);
                             });
                         },
-                        function (oError, oResult) {
-                            aArtifactsServer = aArtifactsServer.map(function (oItem) {
+                        function(oError, oResult) {
+                            aArtifactsServer = aArtifactsServer.map(function(oItem) {
                                 var sId = oItem.id;
 
                                 //remove bsp container at the beginning
@@ -308,11 +309,11 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
                 },
 
                 // L2, step 2: compare against resolved artifacts
-                function (fnCallbackAsyncL2) {
-                    aArtifactsLocal.forEach(function (oItemLocal) {
+                function(fnCallbackAsyncL2) {
+                    aArtifactsLocal.forEach(function(oItemLocal) {
                         var bFound = false;
 
-                        aArtifactsServer.forEach(function (oItemServer) {
+                        aArtifactsServer.forEach(function(oItemServer) {
                             if (oItemLocal.type === oItemServer.type && oItemLocal.id === oItemServer.id) {
                                 bFound = true;
                                 aArtifactsSync.push({
@@ -332,10 +333,10 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
                         }
                     });
 
-                    aArtifactsServer.forEach(function (oItemServer) {
+                    aArtifactsServer.forEach(function(oItemServer) {
                         var bFound = false;
 
-                        aArtifactsLocal.forEach(function (oItemLocal) {
+                        aArtifactsLocal.forEach(function(oItemLocal) {
                             if (oItemLocal.type === oItemServer.type && oItemLocal.id === oItemServer.id) {
                                 bFound = true;
                             }
@@ -353,14 +354,14 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
                     fnCallbackAsyncL2(null, null);
                 }
 
-            ], function (oError, oResult) {
+            ], function(oError, oResult) {
                 fnCallbackAsyncL1(oError, oResult);
             });
 
         },
 
         // L1, step 2: order artifacts for processing
-        function (fnCallbackAsyncL1) {
+        function(fnCallbackAsyncL1) {
             /*
              order of artifacts
              1) DELETE files
@@ -372,18 +373,18 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
              */
 
             // level counter
-            aArtifactsSync = aArtifactsSync.map(function (oItem) {
+            aArtifactsSync = aArtifactsSync.map(function(oItem) {
                 oItem.levelCount = oItem.id.split('/').length - 1;
                 return oItem;
             });
 
             // sort
-            var aDeleteFiles = aArtifactsSync.filter(function (oItem) {
+            var aDeleteFiles = aArtifactsSync.filter(function(oItem) {
                 return (oItem.type === util.OBJECT_TYPE.file && oItem.modif === util.MODIDF.delete);
             });
-            var aDeleteFolders = aArtifactsSync.filter(function (oItem) {
+            var aDeleteFolders = aArtifactsSync.filter(function(oItem) {
                 return (oItem.type === util.OBJECT_TYPE.folder && oItem.modif === util.MODIDF.delete);
-            }).sort(function (oItem1, oItem2) {
+            }).sort(function(oItem1, oItem2) {
                 if (oItem1.levelCount > oItem2.levelCount) {
                     return -1;
                 }
@@ -393,9 +394,9 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
                 return 0;
             });
 
-            var aCreateFolders = aArtifactsSync.filter(function (oItem) {
+            var aCreateFolders = aArtifactsSync.filter(function(oItem) {
                 return (oItem.type === util.OBJECT_TYPE.folder && oItem.modif === util.MODIDF.create);
-            }).sort(function (oItem1, oItem2) {
+            }).sort(function(oItem1, oItem2) {
                 if (oItem1.levelCount < oItem2.levelCount) {
                     return -1;
                 }
@@ -404,13 +405,13 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
                 }
                 return 0;
             });
-            var aUpdateFolders = aArtifactsSync.filter(function (oItem) {
+            var aUpdateFolders = aArtifactsSync.filter(function(oItem) {
                 return (oItem.type === util.OBJECT_TYPE.folder && oItem.modif === util.MODIDF.update);
             });
-            var aCreateFiles = aArtifactsSync.filter(function (oItem) {
+            var aCreateFiles = aArtifactsSync.filter(function(oItem) {
                 return (oItem.type === util.OBJECT_TYPE.file && oItem.modif === util.MODIDF.create);
             });
-            var aUpdateFiles = aArtifactsSync.filter(function (oItem) {
+            var aUpdateFiles = aArtifactsSync.filter(function(oItem) {
                 return (oItem.type === util.OBJECT_TYPE.file && oItem.modif === util.MODIDF.update);
             });
 
@@ -421,22 +422,22 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
         },
 
         // L1, step 3: create BSP container
-        function (fnCallbackAsyncL1) {
+        function(fnCallbackAsyncL1) {
             async.series([
                 me.createBSPContainer.bind(me)
-            ], function (oError, oResult) {
+            ], function(oError, oResult) {
                 fnCallbackAsyncL1(oError, oResult);
             });
         },
 
         // L1, step 4: do synchronization of folders and files
-        function (fnCallbackAsyncL1) {
+        function(fnCallbackAsyncL1) {
 
             async.whilst(
-                function () {
+                function() {
                     return aArtifactsSyncWork.length > 0;
                 },
-                function (fnCallbackAsyncL2) {
+                function(fnCallbackAsyncL2) {
                     var oItem = aArtifactsSyncWork.shift();
 
                     switch (oItem.type) {
@@ -450,22 +451,22 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
                     }
 
                 },
-                function (oError, oResult) {
+                function(oError, oResult) {
                     fnCallbackAsyncL1(oError, oResult);
                 }
             );
         },
 
         // L1, step 5: ensure UI5 Application Index is updated
-        function (fnCallbackAsyncL1) {
+        function(fnCallbackAsyncL1) {
             async.series([
                 me.calcAppIndex.bind(me)
-            ], function (oError, oResult) {
+            ], function(oError, oResult) {
                 fnCallbackAsyncL1(oError, oResult);
             });
         }
 
-    ], function (oError) {
+    ], function(oError) {
         fnCallback(oError, aArtifactsSync);
     });
 };
@@ -477,7 +478,7 @@ FileStore.prototype.syncFiles = function (aFiles, sCwd, fnCallback) {
  * @param {string} sModif modification type (create/update/delete)
  * @param {function} fnCallback callback function
  */
-FileStore.prototype.syncFolder = function (sFolder, sModif, fnCallback) {
+FileStore.prototype.syncFolder = function(sFolder, sModif, fnCallback) {
     var me = this;
 
     var oRequest = null;
@@ -497,14 +498,13 @@ FileStore.prototype.syncFolder = function (sFolder, sModif, fnCallback) {
 
             oRequest = unirest.post(sUrl);
 
-            oRequest.headers(
-                {
-                    'X-CSRF-Token': me._sCSRFToken,
-                    'Content-Type': 'application/octet-stream',
-                    'Accept-Language': 'en-EN',
-                    'accept': '*/*',
-                    'Cookie': me._sSAPCookie
-                });
+            oRequest.headers({
+                'X-CSRF-Token': me._sCSRFToken,
+                'Content-Type': 'application/octet-stream',
+                'Accept-Language': 'en-EN',
+                'accept': '*/*',
+                'Cookie': me._sSAPCookie
+            });
 
             break;
 
@@ -524,15 +524,14 @@ FileStore.prototype.syncFolder = function (sFolder, sModif, fnCallback) {
             }
 
             oRequest = unirest.delete(sUrl);
-            oRequest.headers(
-                {
-                    'X-CSRF-Token': me._sCSRFToken,
-                    'Content-Type': 'application/octet-stream',
-                    'Accept-Language': 'en-EN',
-                    'accept': '*/*',
-                    'Cookie': me._sSAPCookie,
-                    'If-Match': '*'
-                });
+            oRequest.headers({
+                'X-CSRF-Token': me._sCSRFToken,
+                'Content-Type': 'application/octet-stream',
+                'Accept-Language': 'en-EN',
+                'accept': '*/*',
+                'Cookie': me._sSAPCookie,
+                'If-Match': '*'
+            });
 
             break;
 
@@ -541,7 +540,7 @@ FileStore.prototype.syncFolder = function (sFolder, sModif, fnCallback) {
             return;
     }
 
-    me._sendRequest(oRequest, function (oResponse) {
+    me._sendRequest(oRequest, function(oResponse) {
         if (oResponse.error) {
             gutil.log(gutil.colors.red('[FAILED]'), 'Folder', gutil.colors.cyan(sFolder), sModif + 'd.');
             fnCallback(util.createResponseError(oRequest, oResponse), oResponse);
@@ -561,7 +560,7 @@ FileStore.prototype.syncFolder = function (sFolder, sModif, fnCallback) {
  * @param {string} sCwd base folder
  * @param {function} fnCallback callback function
  */
-FileStore.prototype.syncFile = function (sFile, sModif, sCwd, fnCallback) {
+FileStore.prototype.syncFile = function(sFile, sModif, sCwd, fnCallback) {
     var me = this;
 
     var oRequest = null;
@@ -575,7 +574,11 @@ FileStore.prototype.syncFile = function (sFile, sModif, sCwd, fnCallback) {
         var filename = sCwd + sFile; //ILCDBO
         oFileContent = fs.readFileSync(filename);
 
-        bBinaryFile = (isBinaryFile.sync(filename)) ? true : false;
+        if (!this._oOptions.is_ui5_framework) {
+            bBinaryFile = filename.indexOf('.html') === -1 || filename.indexOf('htm') === -1;
+        } else {
+            bBinaryFile = (isBinaryFile.sync(filename)) ? true : false;
+        }
 
         if (/\.properties$/.test(sFile)) {
             sFileCharset = 'ISO-8859-1';
@@ -597,14 +600,13 @@ FileStore.prototype.syncFile = function (sFile, sModif, sCwd, fnCallback) {
             }
 
             oRequest = unirest.post(sUrl);
-            oRequest.headers(
-                {
-                    'X-CSRF-Token': me._sCSRFToken,
-                    'Content-Type': 'application/octet-stream',
-                    'Accept-Language': 'en-EN',
-                    'accept': '*/*',
-                    'Cookie': me._sSAPCookie
-                });
+            oRequest.headers({
+                'X-CSRF-Token': me._sCSRFToken,
+                'Content-Type': 'application/octet-stream',
+                'Accept-Language': 'en-EN',
+                'accept': '*/*',
+                'Cookie': me._sSAPCookie
+            });
 
             if (oFileContent.length > 0) {
                 oRequest.send(oFileContent);
@@ -626,15 +628,14 @@ FileStore.prototype.syncFile = function (sFile, sModif, sCwd, fnCallback) {
             }
 
             oRequest = unirest.put(sUrl);
-            oRequest.headers(
-                {
-                    'X-CSRF-Token': me._sCSRFToken,
-                    'Content-Type': 'application/octet-stream',
-                    'Accept-Language': 'en-EN',
-                    'accept': '*/*',
-                    'Cookie': me._sSAPCookie,
-                    'If-Match': '*'
-                });
+            oRequest.headers({
+                'X-CSRF-Token': me._sCSRFToken,
+                'Content-Type': 'application/octet-stream',
+                'Accept-Language': 'en-EN',
+                'accept': '*/*',
+                'Cookie': me._sSAPCookie,
+                'If-Match': '*'
+            });
 
             if (oFileContent.length > 0) {
                 oRequest.send(oFileContent);
@@ -654,15 +655,14 @@ FileStore.prototype.syncFile = function (sFile, sModif, sCwd, fnCallback) {
             }
 
             oRequest = unirest.delete(sUrl);
-            oRequest.headers(
-                {
-                    'X-CSRF-Token': me._sCSRFToken,
-                    'Content-Type': 'application/octet-stream',
-                    'Accept-Language': 'en-EN',
-                    'accept': '*/*',
-                    'Cookie': me._sSAPCookie,
-                    'If-Match': '*'
-                });
+            oRequest.headers({
+                'X-CSRF-Token': me._sCSRFToken,
+                'Content-Type': 'application/octet-stream',
+                'Accept-Language': 'en-EN',
+                'accept': '*/*',
+                'Cookie': me._sSAPCookie,
+                'If-Match': '*'
+            });
 
             break;
 
@@ -671,7 +671,7 @@ FileStore.prototype.syncFile = function (sFile, sModif, sCwd, fnCallback) {
             return;
     }
 
-    me._sendRequest(oRequest, function (oResponse) {
+    me._sendRequest(oRequest, function(oResponse) {
         if (oResponse.error) {
             gutil.log(gutil.colors.red('[FAILED]'), 'File', gutil.colors.cyan(sFile), sModif + 'd.');
             fnCallback(util.createResponseError(oRequest, oResponse), oResponse);


### PR DESCRIPTION
If application's framework is different than ui5, js files must be deployed as binary to start bsp app. 